### PR TITLE
feat: Add Rundeck installation scripts for Ubuntu

### DIFF
--- a/scripts/install_java.sh
+++ b/scripts/install_java.sh
@@ -67,9 +67,10 @@ success "Java version 11 est correctement installée."
 
 # --- Configuration de JAVA_HOME ---
 info "Configuration de la variable d'environnement JAVA_HOME..."
-JAVA_HOME_PATH=$(update-java-alternatives -l | grep '1.11' | awk '{print $3}')
-if [ -z "$JAVA_HOME_PATH" ]; then
-    error "Impossible de trouver le chemin d'installation de Java 11."
+JAVA_BIN_PATH=$(readlink -f "$(which java)")
+JAVA_HOME_PATH=$(dirname "$(dirname "$JAVA_BIN_PATH")")
+if [ -z "$JAVA_HOME_PATH" ] || [ ! -d "$JAVA_HOME_PATH" ]; then
+    error "Impossible de déterminer le chemin d'installation de Java 11 via readlink."
 fi
 
 if ! grep -q "export JAVA_HOME=" /etc/environment; then

--- a/scripts/install_java.sh
+++ b/scripts/install_java.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# ==============================================================================
+# Script: Installation de Java pour Rundeck
+# ==============================================================================
+
+set -e
+set -o pipefail
+
+# --- Couleurs et Fonctions ---
+C_RESET='\033[0m'; C_RED='\033[0;31m'; C_GREEN='\033[0;32m'; C_YELLOW='\033[0;33m'; C_BLUE='\033[0;34m'
+info() { echo -e    "${C_BLUE}[INFO   ]${C_RESET}ℹ️ $1"; }
+success() { echo -e "${C_GREEN}[SUCCESS]${C_RESET}✅ $1"; }
+warn() { echo -e    "${C_YELLOW}[WARN   ]${C_RESET}⚠️ $1"; }
+error() { echo -e   "${C_RED}[ERROR  ]${C_RESET}❌ $1" >&2; echo ".... Fin le script avec une erreur"; exit 1; }
+start_script() { echo -e "${C_BLUE}[START  ]${C_RESET}🏁 $1🚀"; }
+end_success() { echo -e "${C_GREEN}[END    ]${C_RESET}🏁 $1"; exit 0; }
+
+# --- Liste des Paquets ---
+# OpenJDK 11 est recommandé pour les versions récentes de Rundeck
+PCK_LIST="openjdk-11-jdk"
+
+# --- Début du script ---
+start_script "### Étape 1 : Installation de Java (OpenJDK 11) ###"
+
+# --- Tests Prérequis ---
+info "Vérification des prérequis..."
+if command -v java &>/dev/null; then
+    JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+    info "Java est déjà installé. Version détectée : $JAVA_VERSION"
+    if [[ "$JAVA_VERSION" == "11."* ]]; then
+        success "La version 11 de Java est déjà installée. Aucune action n'est requise."
+        end_success "Installation de Java déjà conforme."
+    else
+        warn "Une autre version de Java est installée. Le script va installer OpenJDK 11."
+    fi
+else
+    info "Java n'est pas encore installé."
+fi
+success "Prérequis validés."
+
+# --- Installation ---
+info "Mise à jour du cache APT et installation des dépendances..."
+apt-get update >/dev/null
+apt-get install -y software-properties-common apt-transport-https wget gpg &>/dev/null || error "L'installation des dépendances a échoué."
+success "Dépendances installées."
+
+info "Installation de la suite de paquets..."
+for pck in $PCK_LIST; do
+  echo " * Installation de $pck..."
+  apt-get install -y "$pck" &>/dev/null || error "L'installation du paquet '$pck' a échoué."
+  success "Le paquet '$pck' a été installé avec succès."
+done
+success "Tous les paquets ont été installés."
+
+# --- Tests Post-Installation ---
+info "Validation de l'installation..."
+if ! command -v java &>/dev/null; then
+    error "La commande 'java' n'a pas été trouvée après l'installation."
+fi
+
+JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+if [[ "$JAVA_VERSION" != "11."* ]]; then
+    error "La version de Java installée n'est pas la 11. Version actuelle : $JAVA_VERSION"
+fi
+success "Java version 11 est correctement installée."
+
+# --- Configuration de JAVA_HOME ---
+info "Configuration de la variable d'environnement JAVA_HOME..."
+JAVA_HOME_PATH=$(update-java-alternatives -l | grep '1.11' | awk '{print $3}')
+if [ -z "$JAVA_HOME_PATH" ]; then
+    error "Impossible de trouver le chemin d'installation de Java 11."
+fi
+
+if ! grep -q "export JAVA_HOME=" /etc/environment; then
+    echo "export JAVA_HOME=$JAVA_HOME_PATH" >> /etc/environment
+    info "JAVA_HOME a été ajouté à /etc/environment."
+else
+    sed -i "/^export JAVA_HOME=/c\export JAVA_HOME=$JAVA_HOME_PATH" /etc/environment
+    info "JAVA_HOME a été mis à jour dans /etc/environment."
+fi
+source /etc/environment
+success "La variable JAVA_HOME a été configurée : $JAVA_HOME"
+
+end_success "Installation et configuration de Java terminées avec succès."

--- a/scripts/install_mysql.sh
+++ b/scripts/install_mysql.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# ==============================================================================
+# Script: Installation de MySQL pour Rundeck
+# ==============================================================================
+
+set -e
+set -o pipefail
+
+# --- Couleurs et Fonctions ---
+C_RESET='\033[0m'; C_RED='\033[0;31m'; C_GREEN='\033[0;32m'; C_YELLOW='\033[0;33m'; C_BLUE='\033[0;34m'
+info() { echo -e    "${C_BLUE}[INFO   ]${C_RESET}ℹ️ $1"; }
+success() { echo -e "${C_GREEN}[SUCCESS]${C_RESET}✅ $1"; }
+warn() { echo -e    "${C_YELLOW}[WARN   ]${C_RESET}⚠️ $1"; }
+error() { echo -e   "${C_RED}[ERROR  ]${C_RESET}❌ $1" >&2; echo ".... Fin le script avec une erreur"; exit 1; }
+start_script() { echo -e "${C_BLUE}[START  ]${C_RESET}🏁 $1🚀"; }
+end_success() { echo -e "${C_GREEN}[END    ]${C_RESET}🏁 $1"; exit 0; }
+
+# --- Variables de Configuration (À MODIFIER POUR LA PRODUCTION) ---
+DB_NAME="rundeck"
+DB_USER="rundeckuser"
+DB_PASS="rundeckpassword" # Attention: Utiliser un mot de passe fort en production.
+
+# --- Liste des Paquets ---
+PCK_LIST="mysql-server"
+
+# --- Début du script ---
+start_script "### Étape 2 : Installation et Configuration de MySQL ###"
+
+# --- Tests Prérequis ---
+info "Vérification des prérequis..."
+if command -v mysql &>/dev/null; then
+    warn "MySQL semble déjà installé. Le script vérifiera la configuration pour Rundeck."
+fi
+success "Prérequis validés."
+
+# --- Installation ---
+info "Mise à jour du cache APT..."
+apt-get update >/dev/null
+info "Installation de MySQL Server..."
+apt-get install -y $PCK_LIST &>/dev/null || error "L'installation de MySQL a échoué."
+success "MySQL a été installé avec succès."
+
+# --- Démarrage et Activation du Service ---
+info "Démarrage et activation du service MySQL..."
+systemctl enable mysql
+systemctl start mysql || error "Le démarrage du service MySQL a échoué."
+success "Le service MySQL a été démarré et activé."
+
+# --- Pause pour démarrage ---
+info "Pause de 10 secondes pour laisser le temps à MySQL de démarrer..."
+sleep 10s
+
+# --- Tests Post-Installation ---
+info "Validation de l'installation de MySQL..."
+if ! systemctl is-active --quiet mysql; then error "Le service MySQL n'a pas pu démarrer."; fi
+if ! ss -tuln | grep -q ':3306'; then error "MySQL n'écoute pas sur le port 3306."; fi
+success "MySQL est actif et répond correctement."
+
+# --- Configuration de la base de données ---
+info "Configuration de la base de données et de l'utilisateur pour Rundeck..."
+warn "Le mot de passe root de MySQL n'est pas défini par ce script. mysql_secure_installation est recommandé."
+
+# Création de la base de données et de l'utilisateur
+# Utilisation d'un bloc 'heredoc' pour passer les commandes SQL
+mysql -u root <<MYSQL_SCRIPT
+CREATE DATABASE IF NOT EXISTS $DB_NAME;
+CREATE USER IF NOT EXISTS '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASS';
+GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER'@'localhost';
+FLUSH PRIVILEGES;
+MYSQL_SCRIPT
+
+if [ $? -ne 0 ]; then
+    error "La création de la base de données ou de l'utilisateur a échoué."
+fi
+success "Base de données '$DB_NAME' et utilisateur '$DB_USER' créés avec succès."
+
+# --- Validation de la configuration ---
+info "Vérification de l'accès à la base de données avec le nouvel utilisateur..."
+if ! mysql -u"$DB_USER" -p"$DB_PASS" -e "use $DB_NAME;"; then
+    error "Impossible de se connecter à la base de données '$DB_NAME' avec l'utilisateur '$DB_USER'."
+fi
+success "La connexion à la base de données Rundeck a été vérifiée avec succès."
+
+end_success "Installation et configuration de MySQL pour Rundeck terminées."

--- a/scripts/install_rundeck.sh
+++ b/scripts/install_rundeck.sh
@@ -75,7 +75,7 @@ sed -i "s|dataSource.username =.*|dataSource.username = $DB_USER|" "$RUNDECK_CON
 sed -i "s|dataSource.password =.*|dataSource.password = $DB_PASS|" "$RUNDECK_CONFIG"
 # Ajout du driver si absent
 if ! grep -q "dataSource.driverClassName" "$RUNDECK_CONFIG"; then
-    echo "dataSource.driverClassName = com.mysql.jdbc.Driver" >> "$RUNDECK_CONFIG"
+    echo "dataSource.driverClassName = com.mysql.cj.jdbc.Driver" >> "$RUNDECK_CONFIG"
 fi
 success "La configuration de la base de données dans '$RUNDECK_CONFIG' a été mise à jour."
 

--- a/scripts/install_rundeck.sh
+++ b/scripts/install_rundeck.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# ==============================================================================
+# Script: Installation de Rundeck
+# ==============================================================================
+
+set -e
+set -o pipefail
+
+# --- Couleurs et Fonctions ---
+C_RESET='\033[0m'; C_RED='\033[0;31m'; C_GREEN='\033[0;32m'; C_YELLOW='\033[0;33m'; C_BLUE='\033[0;34m'
+info() { echo -e    "${C_BLUE}[INFO   ]${C_RESET}ℹ️ $1"; }
+success() { echo -e "${C_GREEN}[SUCCESS]${C_RESET}✅ $1"; }
+warn() { echo -e    "${C_YELLOW}[WARN   ]${C_RESET}⚠️ $1"; }
+error() { echo -e   "${C_RED}[ERROR  ]${C_RESET}❌ $1" >&2; echo ".... Fin le script avec une erreur"; exit 1; }
+start_script() { echo -e "${C_BLUE}[START  ]${C_RESET}🏁 $1🚀"; }
+end_success() { echo -e "${C_GREEN}[END    ]${C_RESET}🏁 $1"; exit 0; }
+
+# --- Variables de Configuration (doivent correspondre à install_mysql.sh) ---
+DB_NAME="rundeck"
+DB_USER="rundeckuser"
+DB_PASS="rundeckpassword"
+RUNDECK_PORT="4440"
+# Récupération de l'adresse IP de la machine pour la configuration de Rundeck
+SERVER_IP=$(hostname -I | awk '{print $1}')
+
+# --- Fichiers de Configuration ---
+RUNDECK_CONFIG="/etc/rundeck/rundeck-config.properties"
+RUNDECK_PROFILE="/etc/rundeck/profile"
+
+# --- Début du script ---
+start_script "### Étape 3 : Installation et Configuration de Rundeck ###"
+
+# --- Tests Prérequis ---
+info "Vérification des prérequis..."
+if ! command -v java &>/dev/null; then
+    error "Java n'est pas installé. Veuillez d'abord exécuter le script d'installation de Java."
+fi
+if ! command -v mysql &>/dev/null; then
+    error "MySQL n'est pas installé. Veuillez d'abord exécuter le script d'installation de MySQL."
+fi
+if [ -f "/etc/rundeck/rundeck-config.properties" ]; then
+    warn "Rundeck semble déjà installé. Le script vérifiera la configuration."
+fi
+success "Prérequis validés."
+
+# --- Installation ---
+info "Configuration du référentiel Rundeck..."
+rm -f /etc/apt/sources.list.d/rundeck.list
+curl -s https://raw.githubusercontent.com/rundeck/packaging/main/scripts/deb-setup.sh | bash &>/dev/null || error "L'ajout du référentiel Rundeck a échoué."
+success "Référentiel Rundeck ajouté."
+
+info "Mise à jour de la liste des paquets..."
+apt-get update &>/dev/null || error "La mise à jour de la liste des paquets a échoué."
+success "Le cache APT a été mis à jour."
+
+info "Installation de Rundeck..."
+apt-get install -y rundeck &>/dev/null || error "L'installation de Rundeck a échoué."
+success "Rundeck a été installé avec succès."
+
+# --- Configuration ---
+info "Configuration de Rundeck pour utiliser MySQL..."
+if [ ! -f "$RUNDECK_CONFIG" ]; then
+    error "Le fichier de configuration de Rundeck '$RUNDECK_CONFIG' n'a pas été trouvé."
+fi
+
+# Sauvegarde du fichier de configuration original
+cp "$RUNDECK_CONFIG" "$RUNDECK_CONFIG.bak"
+
+# Modification du fichier de configuration
+sed -i "s|grails.server.url=.*|grails.server.url=http://$SERVER_IP:$RUNDECK_PORT|" "$RUNDECK_CONFIG"
+sed -i "s|dataSource.dbCreate =.*|dataSource.dbCreate = update|" "$RUNDECK_CONFIG"
+sed -i "s|dataSource.url =.*|dataSource.url = jdbc:mysql://localhost/$DB_NAME?autoReconnect=true&useSSL=false|" "$RUNDECK_CONFIG"
+sed -i "s|dataSource.username =.*|dataSource.username = $DB_USER|" "$RUNDECK_CONFIG"
+sed -i "s|dataSource.password =.*|dataSource.password = $DB_PASS|" "$RUNDECK_CONFIG"
+# Ajout du driver si absent
+if ! grep -q "dataSource.driverClassName" "$RUNDECK_CONFIG"; then
+    echo "dataSource.driverClassName = com.mysql.jdbc.Driver" >> "$RUNDECK_CONFIG"
+fi
+success "La configuration de la base de données dans '$RUNDECK_CONFIG' a été mise à jour."
+
+info "Configuration du port et de l'adresse de Rundeck dans le profil..."
+if [ ! -f "$RUNDECK_PROFILE" ]; then
+    error "Le fichier de profil de Rundeck '$RUNDECK_PROFILE' n'a pas été trouvé."
+fi
+
+# Sauvegarde du fichier de profil original
+cp "$RUNDECK_PROFILE" "$RUNDECK_PROFILE.bak"
+
+sed -i 's/export RDECK_JVM_SETTINGS="-Xmx1024m -Xms256m -server"/export RDECK_JVM_SETTINGS="-Xmx2048m -Xms512m -server"/' "$RUNDECK_PROFILE"
+sed -i "s|-Drundeck.server.http.port=4440|-Drundeck.server.http.port=$RUNDECK_PORT|" "$RUNDECK_PROFILE"
+# Assurer que l'adresse d'écoute est 0.0.0.0 pour être accessible de l'extérieur
+if ! grep -q "rundeck.server.address" "$RUNDECK_PROFILE"; then
+    echo "export RDECK_SERVER_CONFIG=\"\$RDECK_SERVER_CONFIG -Drundeck.server.address=0.0.0.0\"" >> "$RUNDECK_PROFILE"
+fi
+success "Le profil de Rundeck a été mis à jour."
+
+# --- Démarrage et Activation du Service ---
+info "Démarrage et activation du service Rundeck..."
+systemctl daemon-reload
+systemctl enable rundeckd
+systemctl restart rundeckd || error "Le redémarrage du service Rundeck a échoué. Consultez les logs avec 'journalctl -u rundeckd'."
+success "Le service Rundeck a été démarré et activé."
+
+# --- Pause pour démarrage ---
+warn "Rundeck peut prendre plusieurs minutes pour démarrer la première fois. Pause de 90 secondes..."
+sleep 90s
+
+# --- Tests Post-Installation ---
+info "Validation de l'installation de Rundeck..."
+if ! systemctl is-active --quiet rundeckd; then
+    error "Le service Rundeck n'a pas pu démarrer. Consultez les logs : 'journalctl -u rundeckd'."
+fi
+if ! ss -tuln | grep -q ":$RUNDECK_PORT"; then
+    error "Rundeck n'écoute pas sur le port $RUNDECK_PORT."
+fi
+if ! curl -s -I "http://localhost:$RUNDECK_PORT/user/login" | grep -q "HTTP/1.1 200 OK"; then
+    error "La réponse de Rundeck sur localhost:$RUNDECK_PORT est inattendue. Le service est peut-être encore en cours de démarrage."
+fi
+success "Rundeck est actif et répond correctement sur http://$SERVER_IP:$RUNDECK_PORT (login: admin, pass: admin)."
+
+end_success "Installation et configuration de Rundeck terminées avec succès."

--- a/scripts/install_ubuntu.sh
+++ b/scripts/install_ubuntu.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# ==============================================================================
+# Script Principal: Installation complète de la stack Rundeck sur Ubuntu
+# ==============================================================================
+
+set -e
+set -o pipefail
+
+# --- Couleurs et Fonctions ---
+C_RESET='\033[0m'; C_RED='\033[0;31m'; C_GREEN='\033[0;32m'; C_YELLOW='\033[0;33m'; C_BLUE='\033[0;34m'
+info() { echo -e    "${C_BLUE}[INFO   ]${C_RESET}ℹ️ $1"; }
+success() { echo -e "${C_GREEN}[SUCCESS]${C_RESET}✅ $1"; }
+warn() { echo -e    "${C_YELLOW}[WARN   ]${C_RESET}⚠️ $1"; }
+error() { echo -e   "${C_RED}[ERROR  ]${C_RESET}❌ $1" >&2; echo ".... Fin le script avec une erreur"; exit 1; }
+start_script() { echo -e "${C_BLUE}[START  ]${C_RESET}🏁 $1🚀"; }
+end_success() { echo -e "${C_GREEN}[END    ]${C_RESET}🏁 $1"; exit 0; }
+
+# --- Variables ---
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+LOG_FILE="/var/log/rundeck_install_$(date +%Y%m%d_%H%M%S).log"
+
+# --- Scripts à exécuter ---
+INSTALL_SCRIPTS=(
+    "install_java.sh"
+    "install_mysql.sh"
+    "install_rundeck.sh"
+)
+
+# --- Fonctions du script principal ---
+execute_script() {
+    local script_name=$1
+    local script_path="$SCRIPT_DIR/$script_name"
+
+    if [ ! -f "$script_path" ]; then
+        error "Le script requis '$script_name' est introuvable dans le répertoire '$SCRIPT_DIR'."
+    fi
+
+    info "Exécution du script : $script_name..."
+    # Rendre le script exécutable
+    chmod +x "$script_path"
+
+    # Exécuter le script et rediriger la sortie vers le fichier de log et stdout/stderr
+    if ! bash "$script_path" | tee -a "$LOG_FILE"; then
+        error "L'exécution du script '$script_name' a échoué. Consultez '$LOG_FILE' pour plus de détails."
+    fi
+    success "Le script '$script_name' a été exécuté avec succès."
+}
+
+# --- Début du script ---
+start_script "### Installation Complète de la Stack Rundeck sur Ubuntu ###"
+info "Les logs détaillés de cette installation seront enregistrés dans : $LOG_FILE"
+touch "$LOG_FILE" || error "Impossible de créer le fichier de log. Vérifiez les permissions."
+
+# --- Vérification des droits ---
+if [ "$(id -u)" -ne 0 ]; then
+   error "Ce script doit être exécuté en tant que root. Veuillez utiliser 'sudo'."
+fi
+success "Vérification des droits root : OK."
+
+# --- Exécution des scripts d'installation ---
+for script in "${INSTALL_SCRIPTS[@]}"; do
+    execute_script "$script"
+    info "Pause de 5 secondes avant le prochain script..."
+    sleep 5
+done
+
+# --- Message de fin ---
+SERVER_IP=$(hostname -I | awk '{print $1}')
+RUNDECK_PORT="4440"
+success "========================================================================"
+success "Installation de la stack Rundeck terminée !"
+success "URL de Rundeck : http://$SERVER_IP:$RUNDECK_PORT"
+success "Login par défaut : admin"
+success "Mot de passe par défaut : admin"
+warn "N'oubliez pas de changer le mot de passe par défaut et de sécuriser votre installation MySQL."
+success "========================================================================"
+
+end_success "Tous les scripts ont été exécutés avec succès."


### PR DESCRIPTION
This commit introduces a set of shell scripts to automate the installation of a full Rundeck stack on an Ubuntu system.

The installation is broken down into three main components, each with its own script:
- install_java.sh: Installs OpenJDK 11.
- install_mysql.sh: Installs and configures MySQL Server.
- install_rundeck.sh: Installs and configures Rundeck.

A master script, install_ubuntu.sh, is included to execute these scripts in the correct order, providing a single entry point for the entire installation process.

All scripts include error handling, logging, and post-installation checks to ensure a robust setup.

## Summary by Sourcery

Automate the full deployment of a Rundeck stack on Ubuntu by introducing standalone and orchestrating shell scripts for installing Java, MySQL, and Rundeck with built-in logging, error handling, and validation.

New Features:
- Add install_java.sh to install and configure OpenJDK 11 and set JAVA_HOME
- Add install_mysql.sh to install MySQL Server and provision the Rundeck database and user
- Add install_rundeck.sh to install, configure, and start Rundeck with a MySQL backend
- Add install_ubuntu.sh as a master script to orchestrate the sequential execution of all installation steps with centralized logging

Enhancements:
- Include robust error handling, logging, and post-installation checks across all scripts