### PR TITLE
feat: Add Docker environment for Rundeck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore Docker environment file
+docker/.env

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,25 @@
+# Fichier de configuration pour l'environnement Docker de Rundeck
+
+# -- Configuration de l'application Rundeck --
+# Port externe pour accéder à l'interface web de Rundeck
+RUNDECK_PORT=4440
+# URL publique de Rundeck
+RUNDECK_GRAILS_URL=http://localhost:4440
+
+# -- Configuration de la base de données MySQL --
+# Mot de passe root de MySQL (à changer pour un environnement de production)
+MYSQL_ROOT_PASSWORD=rundeck
+# Nom de la base de données pour Rundeck
+MYSQL_DATABASE=rundeck
+# Utilisateur pour la base de données Rundeck
+MYSQL_USER=rundeck
+# Mot de passe pour l'utilisateur de la base de données Rundeck
+MYSQL_PASSWORD=rundeck
+# Port externe pour la base de données MySQL
+MYSQL_PORT=3306
+
+# -- Configuration des volumes de données --
+# Chemin local pour les données de la base de données MySQL
+MYSQL_DATA_DIR=./mysql-data
+# Chemin local pour les données de Rundeck
+RUNDECK_DATA_DIR=./rundeck-data

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,77 @@
+# Makefile pour simplifier la gestion de l'environnement Docker de Rundeck.
+
+# Charge les variables d'environnement depuis le fichier .env
+# Cela permet de les utiliser dans les commandes `docker-compose`.
+include .env
+export
+
+# --- Commandes pour Docker Compose ---
+
+.PHONY: up
+up:
+	@echo "Lancement des conteneurs Rundeck et MySQL avec Docker Compose..."
+	@docker-compose up -d
+
+.PHONY: down
+down:
+	@echo "Arrêt des conteneurs Docker Compose..."
+	@docker-compose down
+
+.PHONY: logs
+logs:
+	@echo "Affichage des logs des conteneurs..."
+	@docker-compose logs -f
+
+.PHONY: ps
+ps:
+	@echo "Liste des conteneurs en cours d'exécution..."
+	@docker-compose ps
+
+.PHONY: restart
+restart:
+	@echo "Redémarrage des services..."
+	@docker-compose restart
+
+# --- Commandes pour Docker Swarm ---
+
+.PHONY: swarm-deploy
+swarm-deploy:
+	@echo "Déploiement de la stack Rundeck sur Docker Swarm..."
+	@docker stack deploy -c docker-swarm.yml rundeck-stack
+
+.PHONY: swarm-rm
+swarm-rm:
+	@echo "Suppression de la stack Rundeck de Docker Swarm..."
+	@docker stack rm rundeck-stack
+
+.PHONY: swarm-services
+swarm-services:
+	@echo "Liste des services de la stack Rundeck..."
+	@docker stack services rundeck-stack
+
+# --- Commandes de nettoyage ---
+
+.PHONY: clean
+clean: down
+	@echo "Nettoyage des volumes de données (ATTENTION: supprime toutes les données)..."
+	@docker volume rm $(shell basename `pwd` | sed -e 's/[^a-zA-Z0-9_.-]//g')_rundeck-data || true
+	@docker volume rm $(shell basename `pwd` | sed -e 's/[^a-zA-Z0-9_.-]//g')_mysql-data || true
+	@echo "Suppression des répertoires de données locaux..."
+	@rm -rf ${RUNDECK_DATA_DIR}
+	@rm -rf ${MYSQL_DATA_DIR}
+
+.PHONY: help
+help:
+	@echo "Commandes disponibles :"
+	@echo "  up              - Démarre les conteneurs en arrière-plan (Docker Compose)."
+	@echo "  down            - Arrête et supprime les conteneurs (Docker Compose)."
+	@echo "  logs            - Affiche les logs des conteneurs."
+	@echo "  ps              - Liste les conteneurs en cours."
+	@echo "  restart         - Redémarre les services."
+	@echo ""
+	@echo "  swarm-deploy    - Déploie la stack sur Docker Swarm."
+	@echo "  swarm-rm        - Supprime la stack de Docker Swarm."
+	@echo "  swarm-services  - Liste les services de la stack."
+	@echo ""
+	@echo "  clean           - Arrête les conteneurs et supprime les volumes de données."
+	@echo "  help            - Affiche ce message d'aide."

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,71 @@
+# Fichier docker-compose pour le déploiement de Rundeck avec une base de données MySQL.
+# Version de la syntaxe docker-compose.
+version: '3.7'
+
+services:
+  # Service pour l'application Rundeck.
+  rundeck:
+    # Image Docker à utiliser pour Rundeck.
+    image: rundeck/rundeck:4.17.6
+    # Nom du conteneur.
+    container_name: rundeck
+    # Redémarre toujours le conteneur s'il s'arrête.
+    restart: always
+    # Variables d'environnement pour configurer Rundeck.
+    environment:
+      # URL publique de Rundeck, utilisée pour générer les URLs.
+      RUNDECK_GRAILS_URL: ${RUNDECK_GRAILS_URL}
+      # -- Configuration de la base de données --
+      # Driver JDBC pour MySQL.
+      RUNDECK_DATABASE_DRIVER: org.mariadb.jdbc.Driver
+      # URL de connexion à la base de données MySQL.
+      RUNDECK_DATABASE_URL: jdbc:mysql://db:3306/${MYSQL_DATABASE}?autoReconnect=true&useSSL=false
+      # Nom d'utilisateur pour la base de données.
+      RUNDECK_DATABASE_USERNAME: ${MYSQL_USER}
+      # Mot de passe pour la base de données.
+      RUNDECK_DATABASE_PASSWORD: ${MYSQL_PASSWORD}
+    # Mappage des ports. Le port 4440 du conteneur est mappé au port RUNDECK_PORT de l'hôte.
+    ports:
+      - "${RUNDECK_PORT}:4440"
+    # Dépend du service 'db', donc 'db' sera démarré avant 'rundeck'.
+    depends_on:
+      - db
+    # Volumes pour la persistance des données.
+    volumes:
+      # Mappe le répertoire local RUNDECK_DATA_DIR aux données de Rundeck dans le conteneur.
+      - ${RUNDECK_DATA_DIR}:/home/rundeck/server/data
+      # Vous pouvez ajouter d'autres volumes pour les projets, les clés, etc.
+      # - ./projects:/home/rundeck/projects
+      # - ./keys:/home/rundeck/var/lib/rundeck/.ssh
+
+  # Service pour la base de données MySQL.
+  db:
+    # Image Docker à utiliser pour MySQL.
+    image: mysql:8.0
+    # Nom du conteneur.
+    container_name: mysql-db
+    # Redémarre toujours le conteneur s'il s'arrête.
+    restart: always
+    # Variables d'environnement pour configurer MySQL.
+    environment:
+      # Mot de passe root pour MySQL.
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      # Nom de la base de données à créer au démarrage.
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      # Nom d'utilisateur à créer.
+      MYSQL_USER: ${MYSQL_USER}
+      # Mot de passe pour l'utilisateur.
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    # Mappage des ports. Le port 3306 du conteneur est mappé au port MYSQL_PORT de l'hôte.
+    ports:
+        - "${MYSQL_PORT}:3306"
+    # Volume pour la persistance des données de la base de données.
+    volumes:
+      # Mappe le répertoire local MYSQL_DATA_DIR aux données de MySQL dans le conteneur.
+      - ${MYSQL_DATA_DIR}:/var/lib/mysql
+
+# Définition des volumes nommés pour une gestion plus facile.
+# Si vous n'utilisez pas de chemins locaux (comme ci-dessus), vous pouvez définir des volumes ici.
+# volumes:
+#   rundeck-data:
+#   mysql-data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     # Mappage des ports. Le port 3306 du conteneur est mappé au port MYSQL_PORT de l'hôte.
     ports:
-        - "${MYSQL_PORT}:3306"
+      - "${MYSQL_PORT}:3306"
     # Volume pour la persistance des données de la base de données.
     volumes:
       # Mappe le répertoire local MYSQL_DATA_DIR aux données de MySQL dans le conteneur.

--- a/docker/docker-swarm.yml
+++ b/docker/docker-swarm.yml
@@ -1,0 +1,68 @@
+# Fichier de configuration pour le déploiement de Rundeck en mode Docker Swarm.
+# Ce fichier est destiné à être utilisé avec la commande 'docker stack deploy'.
+version: '3.7'
+
+services:
+  # Service pour l'application Rundeck.
+  rundeck:
+    # Image Docker à utiliser pour Rundeck.
+    image: rundeck/rundeck:4.17.6
+    # Variables d'environnement lues à partir du fichier .env.
+    # Assurez-vous que les variables sont disponibles sur le manager Swarm.
+    environment:
+      RUNDECK_GRAILS_URL: ${RUNDECK_GRAILS_URL}
+      RUNDECK_DATABASE_DRIVER: org.mariadb.jdbc.Driver
+      RUNDECK_DATABASE_URL: jdbc:mysql://db:3306/${MYSQL_DATABASE}?autoReconnect=true&useSSL=false
+      RUNDECK_DATABASE_USERNAME: ${MYSQL_USER}
+      RUNDECK_DATABASE_PASSWORD: ${MYSQL_PASSWORD}
+    # Mappage des ports.
+    ports:
+      - "${RUNDECK_PORT}:4440"
+    # Dépendances de service.
+    depends_on:
+      - db
+    # Volumes pour la persistance des données.
+    volumes:
+      - rundeck-data:/home/rundeck/server/data
+    # Configuration du déploiement pour le mode Swarm.
+    deploy:
+      # Mode de réplication : un seul réplica pour cette configuration simple.
+      mode: replicated
+      replicas: 1
+      # Contraintes de placement : peut être utilisé pour déployer sur des nœuds spécifiques.
+      placement:
+        constraints: [node.role == manager] # Exemple : déployer sur un nœud manager.
+      # Politique de redémarrage en cas d'échec.
+      restart_policy:
+        condition: on-failure
+
+  # Service pour la base de données MySQL.
+  db:
+    # Image Docker pour MySQL.
+    image: mysql:8.0
+    # Variables d'environnement pour MySQL.
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    # Volumes pour la persistance des données.
+    volumes:
+      - mysql-data:/var/lib/mysql
+    # Configuration du déploiement pour le mode Swarm.
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints: [node.role == manager] # Déployer sur le même nœud que Rundeck pour cet exemple.
+      restart_policy:
+        condition: on-failure
+
+# Volumes pour la persistance des données en mode Swarm.
+# Ces volumes seront gérés par Docker Swarm.
+volumes:
+  rundeck-data:
+    # Driver de volume (local par défaut).
+    driver: local
+  mysql-data:
+    driver: local

--- a/docker/jobs/sample-job.yml
+++ b/docker/jobs/sample-job.yml
@@ -1,0 +1,44 @@
+# Fichier d'exemple de définition de job Rundeck au format YAML.
+# Ce fichier peut être importé dans un projet Rundeck.
+
+# Chaque document YAML (séparé par ---) représente un job.
+-
+  # Nom du job.
+  name: "Exemple de Job - Dire Bonjour"
+  # Description du job, visible dans l'interface de Rundeck.
+  description: "Un simple job qui affiche 'Bonjour le monde'."
+  # Niveau de log pour l'exécution du job (INFO, DEBUG, etc.).
+  loglevel: "INFO"
+  # Séquence des étapes à exécuter.
+  sequence:
+    # Continue l'exécution même si une étape échoue.
+    keepgoing: false
+    # Stratégie d'exécution des étapes (séquentielle par défaut).
+    strategy: "node-first"
+    # Liste des commandes à exécuter.
+    commands:
+      -
+        # Commande shell à exécuter.
+        exec: "echo 'Bonjour le monde, depuis Rundeck !'"
+  # Contexte du job (sur quels nœuds s'exécute-t-il ?).
+  nodefilters:
+    # Filtre pour sélectionner les nœuds.
+    filter: ".*" # Exécute sur tous les nœuds.
+  # Options du job (paramètres d'entrée).
+  options:
+    -
+      # Nom de l'option.
+      name: "nom_utilisateur"
+      # Label affiché dans l'interface.
+      label: "Nom de l'utilisateur"
+      # Description de l'option.
+      description: "Entrez un nom d'utilisateur à saluer."
+      # Valeur par défaut.
+      defaultValue: "Admin"
+      # Est-ce que l'option est requise ?
+      required: true
+# Vous pouvez ajouter d'autres jobs ci-dessous, séparés par ---
+# ---
+# -
+#   name: "Un autre Job"
+#   ...


### PR DESCRIPTION
This commit introduces a complete Docker environment for running Rundeck, including configurations for both local development with Docker Compose and deployment with Docker Swarm.

The setup includes:
- A `docker-compose.yml` for local development.
- A `docker-swarm.yml` for production-like deployments.
- A `Makefile` with helper commands to manage the environment.
- A `.env.example` file to provide a template for environment variables.
- A sample Rundeck job in YAML format.
- A `.gitignore` file to exclude the `.env` file from version control.

All files are commented in French as per project conventions.

## Summary by Sourcery

Provide a full Docker environment for Rundeck, enabling both local development via Docker Compose and production-like deployment via Docker Swarm, with accompanying helper scripts and templates.

New Features:
- Add Docker Compose configuration for Rundeck and MySQL.
- Add Docker Swarm stack configuration for Rundeck deployment.
- Introduce Makefile with commands for managing Docker Compose and Swarm stacks.
- Include .env.example template for environment variables.
- Provide a sample Rundeck job definition in YAML format.

Enhancements:
- Update .gitignore to exclude the .env file.