### PR TITLE
feat: Add markdown documentation for project directories

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,67 @@
+# Documentation de l'environnement Docker
+
+Ce répertoire contient la configuration Docker pour déployer Rundeck et une base de données MySQL. Il est conçu pour être utilisé avec Docker Compose pour le développement local et Docker Swarm pour un environnement de production.
+
+## Contenu
+
+- [`docker-compose.yml`](#docker-compose)
+- [`docker-swarm.yml`](#docker-swarm)
+- [`Makefile`](#makefile)
+- `jobs/` : Ce répertoire est destiné à contenir des définitions de jobs Rundeck qui peuvent être montées en volume dans le conteneur Rundeck.
+
+---
+
+### Docker Compose
+
+Le fichier `docker-compose.yml` est utilisé pour lancer un environnement de développement local. Il définit deux services :
+- `rundeck` : L'application Rundeck.
+- `db` : La base de données MySQL.
+
+**Caractéristiques :**
+- Les données de Rundeck et de MySQL sont persistées dans des répertoires locaux (`./data/rundeck` et `./data/mysql`) pour un accès facile.
+- La configuration (ports, identifiants) est gérée via un fichier `.env`.
+
+**Utilisation :**
+1. Créez un fichier `.env` à la racine du répertoire `docker` en vous basant sur `.env.example`.
+2. Exécutez `make up` pour démarrer les conteneurs.
+
+---
+
+### Docker Swarm
+
+Le fichier `docker-swarm.yml` est conçu pour un déploiement sur un cluster Docker Swarm.
+
+**Caractéristiques :**
+- Utilise des volumes nommés gérés par Swarm pour la persistance des données.
+- Configuré pour un déploiement sur un nœud manager (peut être ajusté).
+
+**Utilisation :**
+1. Assurez-vous que votre environnement Swarm est initialisé.
+2. Assurez-vous que les variables d'environnement nécessaires sont disponibles sur le nœud manager.
+3. Déployez la stack avec `make swarm-deploy`.
+
+---
+
+### Makefile
+
+Le `Makefile` simplifie la gestion de l'environnement Docker avec des commandes courtes et faciles à retenir.
+
+**Commandes principales :**
+
+*   **Pour Docker Compose :**
+    *   `make up` : Démarre les conteneurs en arrière-plan.
+    *   `make down` : Arrête et supprime les conteneurs.
+    *   `make logs` : Affiche les logs des conteneurs.
+    *   `make ps` : Liste les conteneurs en cours d'exécution.
+    *   `make restart` : Redémarre les services.
+
+*   **Pour Docker Swarm :**
+    *   `make swarm-deploy` : Déploie la stack sur le cluster Swarm.
+    *   `make swarm-rm` : Supprime la stack du cluster.
+    *   `make swarm-services` : Liste les services de la stack.
+
+*   **Nettoyage :**
+    *   `make clean` : Arrête les conteneurs et supprime tous les volumes de données (local et Docker). **Attention, cette commande est destructive.**
+
+*   **Aide :**
+    *   `make help` : Affiche la liste de toutes les commandes disponibles.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,65 @@
+# Documentation des Scripts d'Installation
+
+Ce répertoire contient une collection de scripts Bash conçus pour automatiser l'installation et la configuration d'une stack Rundeck complète sur un système Ubuntu.
+
+## Contenu
+
+- [`install_ubuntu.sh`](#script-principal-install_ubuntush)
+- [`install_java.sh`](#script-dinstallation-de-java)
+- [`install_mysql.sh`](#script-dinstallation-de-mysql)
+- [`install_rundeck.sh`](#script-dinstallation-de-rundeck)
+
+---
+
+### Script Principal: `install_ubuntu.sh`
+
+C'est le script principal à exécuter. Il orchestre l'exécution des autres scripts dans le bon ordre pour installer la stack complète.
+
+**Fonctionnalités :**
+- Vérifie les droits `root`.
+- Exécute séquentiellement `install_java.sh`, `install_mysql.sh`, et `install_rundeck.sh`.
+- Centralise les logs de l'ensemble du processus d'installation dans `/var/log/rundeck_install_*.log`.
+- Affiche un résumé à la fin avec l'URL d'accès à Rundeck.
+
+**Utilisation :**
+Assurez-vous que tous les scripts sont dans le même répertoire, puis exécutez :
+```bash
+sudo ./install_ubuntu.sh
+```
+
+---
+
+### Script d'installation de Java
+
+Le script `install_java.sh` installe OpenJDK 11, qui est une dépendance requise pour Rundeck.
+
+**Fonctionnalités :**
+- Vérifie si Java 11 est déjà installé.
+- Installe `openjdk-11-jdk`.
+- Configure la variable d'environnement `JAVA_HOME` dans `/etc/environment` pour l'ensemble du système.
+
+---
+
+### Script d'installation de MySQL
+
+Le script `install_mysql.sh` installe le serveur de base de données MySQL et le prépare pour Rundeck.
+
+**Fonctionnalités :**
+- Installe `mysql-server`.
+- Démarre et active le service MySQL.
+- Crée une base de données (`rundeck`) et un utilisateur (`rundeckuser`) pour que Rundeck puisse s'y connecter.
+- **Note :** Les identifiants sont codés en dur dans le script. Pour un usage en production, il est fortement recommandé de les modifier et de sécuriser l'installation MySQL.
+
+---
+
+### Script d'installation de Rundeck
+
+Le script `install_rundeck.sh` installe l'application Rundeck elle-même.
+
+**Fonctionnalités :**
+- Ajoute le référentiel officiel de Rundeck.
+- Installe le paquet `rundeck`.
+- Configure Rundeck pour se connecter à la base de données MySQL créée précédemment.
+- Configure l'URL du serveur et l'adresse d'écoute pour rendre Rundeck accessible sur le réseau.
+- Démarre et active le service `rundeckd`.
+- Attend que l'application soit pleinement démarrée et teste l'accès.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,59 @@
+# Documentation des Templates Rundeck
+
+Ce répertoire contient des templates de jobs pour Rundeck, prêts à l'emploi pour différentes technologies. Chaque template est fourni au format YAML et peut être importé directement dans votre projet Rundeck.
+
+## Contenu
+
+- [`ansible_job_template.yaml`](#template-job-ansible)
+- [`bash_job_template.yaml`](#template-job-bash)
+- [`python_job_template.yaml`](#template-job-python)
+
+---
+
+### Template Job Ansible
+
+Le fichier `ansible_job_template.yaml` est un template pour un job Rundeck qui exécute un playbook Ansible.
+
+**Caractéristiques :**
+- Exécute un playbook Ansible spécifié.
+- Configure l'inventaire, l'utilisateur SSH, et la clé privée.
+- Gère l'escalade de privilèges (`become`).
+- Envoie des notifications par email en cas de succès ou d'échec.
+
+**Utilisation :**
+1. Personnalisez les chemins d'accès au playbook, à l'inventaire et à la clé SSH.
+2. Adaptez les informations de notification (destinataires, etc.).
+3. Importez le fichier YAML dans votre projet Rundeck.
+
+---
+
+### Template Job Bash
+
+Le fichier `bash_job_template.yaml` est un template pour un job Rundeck qui exécute une série de commandes Bash.
+
+**Caractéristiques :**
+- Workflow séquentiel avec trois étapes de commandes Bash.
+- Le job s'arrête si une étape échoue.
+- Envoie des notifications par email en cas de succès ou d'échec.
+
+**Utilisation :**
+1. Modifiez les commandes `exec` dans chaque étape pour correspondre à vos besoins.
+2. Configurez les notifications.
+3. Importez le fichier YAML dans Rundeck.
+
+---
+
+### Template Job Python
+
+Le fichier `python_job_template.yaml` est un template pour un job Rundeck qui exécute des scripts Python.
+
+**Caractéristiques :**
+- Exécute des scripts Python directement dans les étapes du job.
+- Workflow séquentiel en trois étapes.
+- Le job s'arrête en cas d'échec d'une étape.
+- Notifications par email pour le suivi du statut du job.
+
+**Utilisation :**
+1. Remplacez le contenu des balises `script` par votre code Python.
+2. Ajustez les paramètres de notification.
+3. Importez le fichier YAML dans votre projet Rundeck.


### PR DESCRIPTION
This commit adds `README.md` files to the `templates`, `docker`, and `scripts` directories to document their contents.

- The `templates/README.md` file explains the purpose of each Rundeck job template (Ansible, Bash, Python).
- The `docker/README.md` file documents the Docker Compose and Docker Swarm setups, as well as the available `Makefile` commands.
- The `scripts/README.md` file provides an overview of the shell scripts used for installing the Rundeck stack on Ubuntu.

## Summary by Sourcery

Add README.md files to the templates, docker, and scripts directories to document their contents and usage.

Documentation:
- Add templates/README.md documenting Ansible, Bash, and Python Rundeck job templates.
- Add docker/README.md describing Docker Compose and Docker Swarm setups and available Makefile commands.
- Add scripts/README.md outlining Bash scripts for automated installation and configuration of the Rundeck stack on Ubuntu.