### PR TITLE
feat: Add main README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Projet d'Automatisation et de Déploiement de Rundeck
+
+Ce projet fournit une collection complète d'outils pour déployer, configurer et gérer un environnement Rundeck. Il est divisé en plusieurs répertoires, chacun se concentrant sur un aspect spécifique de l'automatisation.
+
+## Répertoires
+
+### [Ansible](./ansible/README.md)
+Ce répertoire contient les playbooks et les rôles Ansible pour automatiser le déploiement de la stack Rundeck (Java, MySQL, Rundeck, Keycloak).
+
+### [Docker](./docker/README.md)
+Vous trouverez ici les configurations Docker pour lancer rapidement un environnement de développement local ou de production avec Docker Compose et Docker Swarm.
+
+### [Scripts](./scripts/README.md)
+Une collection de scripts Bash pour une installation manuelle et automatisée de la stack Rundeck sur un système Ubuntu.
+
+### [Templates](./templates/README.md)
+Contient des templates de jobs Rundeck au format YAML, prêts à être importés, pour exécuter des tâches avec Ansible, Bash ou Python.


### PR DESCRIPTION
This commit introduces a main `README.md` file at the root of the project.

The new `README.md` file provides a high-level overview of the project and describes the contents of each subdirectory: `ansible`, `docker`, `scripts`, and `templates`. It also includes relative links to the `README.md` file within each subdirectory for more detailed information.

## Summary by Sourcery

Documentation:
- Introduce root-level documentation summarizing project purpose and describing contents of ansible, docker, scripts, and templates directories with relative links to their READMEs