### PR TITLE
feat(scripts): Add Rundeck backup and restore scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,8 @@ Ce répertoire contient une collection de scripts Bash conçus pour automatiser 
 - [`install_java.sh`](#script-dinstallation-de-java)
 - [`install_mysql.sh`](#script-dinstallation-de-mysql)
 - [`install_rundeck.sh`](#script-dinstallation-de-rundeck)
+- [`backup_rundeck.sh`](#script-de-sauvegarde-backup_rundecksh)
+- [`restore_rundeck.sh`](#script-de-restauration-restore_rundecksh)
 
 ---
 
@@ -63,3 +65,45 @@ Le script `install_rundeck.sh` installe l'application Rundeck elle-même.
 - Configure l'URL du serveur et l'adresse d'écoute pour rendre Rundeck accessible sur le réseau.
 - Démarre et active le service `rundeckd`.
 - Attend que l'application soit pleinement démarrée et teste l'accès.
+
+---
+
+### Script de Sauvegarde: `backup_rundeck.sh`
+
+Ce script permet de créer une sauvegarde complète de l'instance Rundeck.
+
+**Fonctionnalités :**
+- Arrête le service `rundeckd` pour assurer la cohérence des données.
+- Sauvegarde la base de données MySQL `rundeck` via `mysqldump`.
+- Crée une archive `.tar.gz` contenant :
+  - Le dump de la base de données.
+  - Les logs (`/var/lib/rundeck/logs`).
+  - Les keystores (`/var/lib/rundeck/keystore`).
+  - Les définitions de projets (`/var/lib/rundeck/projects`).
+  - Les fichiers de configuration (`/etc/rundeck`).
+- Redémarre le service `rundeckd` une fois la sauvegarde terminée.
+- Stocke la sauvegarde dans `/var/backups/rundeck/` avec un horodatage.
+
+**Utilisation :**
+```bash
+sudo ./backup_rundeck.sh
+```
+
+---
+
+### Script de Restauration: `restore_rundeck.sh`
+
+Ce script permet de restaurer Rundeck à partir d'un fichier de sauvegarde créé par `backup_rundeck.sh`.
+
+**Fonctionnalités :**
+- Prend le chemin vers un fichier de sauvegarde en argument.
+- Arrête le service `rundeckd`.
+- Restaure la base de données MySQL à partir du dump SQL contenu dans l'archive.
+- Supprime les anciennes données et restaure les fichiers et répertoires de Rundeck.
+- Rétablit les permissions (`chown`) pour l'utilisateur `rundeck`.
+- Redémarre le service `rundeckd`.
+
+**Utilisation :**
+```bash
+sudo ./restore_rundeck.sh /var/backups/rundeck/rundeck_backup_YYYYMMDD_HHMMSS.tar.gz
+```

--- a/scripts/backup_rundeck.sh
+++ b/scripts/backup_rundeck.sh
@@ -96,10 +96,19 @@ tar -czf "$BACKUP_FILE" \
 }
 success "Archive de sauvegarde créée : $BACKUP_FILE"
 
-# --- Nettoyage ---
-info "Nettoyage du fichier de sauvegarde temporaire de la base de données..."
-rm -f "$DB_BACKUP_FILE"
-success "Fichier temporaire supprimé."
+# --- Vérification de l'intégrité de l'archive ---
+info "Vérification de l'intégrité de l'archive de sauvegarde..."
+if tar -tzf "$BACKUP_FILE" > /dev/null 2>&1; then
+    success "L'intégrité de l'archive est confirmée."
+    # --- Nettoyage ---
+    info "Nettoyage du fichier de sauvegarde temporaire de la base de données..."
+    rm -f "$DB_BACKUP_FILE"
+    success "Fichier temporaire supprimé."
+else
+    error "L'archive de sauvegarde est corrompue. Le fichier temporaire n'a pas été supprimé."
+    # Optionally, handle the error (e.g., exit, alert, etc.)
+    exit 1
+fi
 
 # --- Redémarrage du service Rundeck ---
 info "Redémarrage du service Rundeck..."

--- a/scripts/backup_rundeck.sh
+++ b/scripts/backup_rundeck.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# ==============================================================================
+# Script: Sauvegarde de Rundeck
+# Description: Ce script arrête Rundeck, sauvegarde la base de données et les
+#              fichiers importants, puis redémarre Rundeck.
+# ==============================================================================
+
+set -e
+set -o pipefail
+
+# --- Couleurs et Fonctions ---
+C_RESET='\033[0m'; C_RED='\033[0;31m'; C_GREEN='\033[0;32m'; C_YELLOW='\033[0;33m'; C_BLUE='\033[0;34m'
+info() { echo -e    "${C_BLUE}[INFO   ]${C_RESET}ℹ️ $1"; }
+success() { echo -e "${C_GREEN}[SUCCESS]${C_RESET}✅ $1"; }
+warn() { echo -e    "${C_YELLOW}[WARN   ]${C_RESET}⚠️ $1"; }
+error() { echo -e   "${C_RED}[ERROR  ]${C_RESET}❌ $1" >&2; echo ".... Fin du script avec une erreur"; exit 1; }
+start_script() { echo -e "${C_BLUE}[START  ]${C_RESET}🏁 $1🚀"; }
+end_success() { echo -e "${C_GREEN}[END    ]${C_RESET}🏁 $1"; exit 0; }
+
+# --- Variables de Configuration (doivent correspondre à install_mysql.sh) ---
+DB_NAME="rundeck"
+DB_USER="rundeckuser"
+DB_PASS="rundeckpassword"
+
+# --- Répertoire de Sauvegarde ---
+BACKUP_DIR="/var/backups/rundeck"
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+BACKUP_FILE="$BACKUP_DIR/rundeck_backup_$TIMESTAMP.tar.gz"
+DB_BACKUP_FILE="/tmp/rundeck_db_$TIMESTAMP.sql"
+
+# --- Répertoires à sauvegarder ---
+RUNDECK_LOGS_DIR="/var/lib/rundeck/logs"
+RUNDECK_KEYSTORE_DIR="/var/lib/rundeck/keystore"
+RUNDECK_PROJECTS_DIR="/var/lib/rundeck/projects"
+RUNDECK_CONFIG_DIR="/etc/rundeck"
+
+# --- Début du script ---
+start_script "### Sauvegarde de Rundeck ###"
+
+# --- Vérification des droits root ---
+if [ "$(id -u)" -ne 0 ]; then
+    error "Ce script doit être exécuté en tant que root. Utilisez 'sudo'."
+fi
+
+# --- Création du répertoire de sauvegarde ---
+info "Création du répertoire de sauvegarde s'il n'existe pas..."
+mkdir -p "$BACKUP_DIR"
+success "Répertoire de sauvegarde prêt : $BACKUP_DIR"
+
+# --- Arrêt du service Rundeck ---
+info "Arrêt du service Rundeck pour garantir la cohérence des données..."
+if systemctl is-active --quiet rundeckd; then
+    systemctl stop rundeckd || error "Échec de l'arrêt du service Rundeck."
+    success "Service Rundeck arrêté."
+else
+    warn "Le service Rundeck n'était pas en cours d'exécution."
+fi
+
+# --- Sauvegarde de la base de données ---
+info "Sauvegarde de la base de données MySQL '$DB_NAME'..."
+mysqldump --user="$DB_USER" --password="$DB_PASS" "$DB_NAME" > "$DB_BACKUP_FILE" || {
+    error "La sauvegarde de la base de données a échoué."
+    # Redémarrer Rundeck même en cas d'échec
+    info "Tentative de redémarrage du service Rundeck..."
+    systemctl start rundeckd
+    exit 1
+}
+success "Base de données sauvegardée dans '$DB_BACKUP_FILE'."
+
+# --- Sauvegarde des fichiers ---
+info "Création de l'archive des fichiers de Rundeck..."
+tar -czf "$BACKUP_FILE" \
+    -C /tmp "$(basename "$DB_BACKUP_FILE")" \
+    -C "$(dirname "$RUNDECK_LOGS_DIR")" "$(basename "$RUNDECK_LOGS_DIR")" \
+    -C "$(dirname "$RUNDECK_KEYSTORE_DIR")" "$(basename "$RUNDECK_KEYSTORE_DIR")" \
+    -C "$(dirname "$RUNDECK_PROJECTS_DIR")" "$(basename "$RUNDECK_PROJECTS_DIR")" \
+    -C /etc "rundeck" || {
+    error "La création de l'archive de sauvegarde a échoué."
+    # Redémarrer Rundeck même en cas d'échec
+    info "Tentative de redémarrage du service Rundeck..."
+    systemctl start rundeckd
+    exit 1
+}
+success "Archive de sauvegarde créée : $BACKUP_FILE"
+
+# --- Nettoyage ---
+info "Nettoyage du fichier de sauvegarde temporaire de la base de données..."
+rm -f "$DB_BACKUP_FILE"
+success "Fichier temporaire supprimé."
+
+# --- Redémarrage du service Rundeck ---
+info "Redémarrage du service Rundeck..."
+systemctl start rundeckd || error "Le redémarrage du service Rundeck a échoué."
+success "Service Rundeck redémarré avec succès."
+
+end_success "Sauvegarde de Rundeck terminée avec succès."

--- a/scripts/restore_rundeck.sh
+++ b/scripts/restore_rundeck.sh
@@ -121,8 +121,9 @@ info "Restauration des nouveaux répertoires..."
 mv "$EXTRACT_DIR/logs" /var/lib/rundeck/
 mv "$EXTRACT_DIR/keystore" /var/lib/rundeck/
 mv "$EXTRACT_DIR/projects" /var/lib/rundeck/
-mv "$EXTRACT_DIR/rundeck" /etc/
-success "Nouveaux répertoires restaurés."
+info "Fusion des fichiers restaurés dans /etc/rundeck (les fichiers existants seront écrasés si présents)..."
+rsync -a "$EXTRACT_DIR/rundeck/" /etc/rundeck/
+success "Nouveaux répertoires restaurés et fusionnés dans /etc/rundeck."
 
 # --- Rétablissement des permissions ---
 info "Rétablissement des permissions pour les fichiers Rundeck..."

--- a/scripts/restore_rundeck.sh
+++ b/scripts/restore_rundeck.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# ==============================================================================
+# Script: Restauration de Rundeck
+# Description: Ce script arrête Rundeck, restaure la base de données et les
+#              fichiers à partir d'une sauvegarde, puis redémarre Rundeck.
+# Utilisation: sudo ./restore_rundeck.sh /chemin/vers/votre/backup.tar.gz
+# ==============================================================================
+
+set -e
+set -o pipefail
+
+# --- Couleurs et Fonctions ---
+C_RESET='\033[0m'; C_RED='\033[0;31m'; C_GREEN='\033[0;32m'; C_YELLOW='\033[0;33m'; C_BLUE='\033[0;34m'
+info() { echo -e    "${C_BLUE}[INFO   ]${C_RESET}ℹ️ $1"; }
+success() { echo -e "${C_GREEN}[SUCCESS]${C_RESET}✅ $1"; }
+warn() { echo -e    "${C_YELLOW}[WARN   ]${C_RESET}⚠️ $1"; }
+error() { echo -e   "${C_RED}[ERROR  ]${C_RESET}❌ $1" >&2; echo ".... Fin du script avec une erreur"; exit 1; }
+start_script() { echo -e "${C_BLUE}[START  ]${C_RESET}🏁 $1🚀"; }
+end_success() { echo -e "${C_GREEN}[END    ]${C_RESET}🏁 $1"; exit 0; }
+
+# --- Fichier de Sauvegarde ---
+if [ "$#" -ne 1 ]; then
+    error "Utilisation : $0 /chemin/vers/le/fichier_de_backup.tar.gz"
+fi
+BACKUP_FILE="$1"
+
+# --- Variables de Configuration (doivent correspondre à install_mysql.sh) ---
+DB_NAME="rundeck"
+DB_USER="rundeckuser"
+DB_PASS="rundeckpassword"
+
+# --- Répertoire Temporaire pour l'Extraction ---
+EXTRACT_DIR="/tmp/rundeck_restore_$$"
+
+# --- Début du script ---
+start_script "### Restauration de Rundeck ###"
+
+# --- Vérification des droits root ---
+if [ "$(id -u)" -ne 0 ]; then
+    error "Ce script doit être exécuté en tant que root. Utilisez 'sudo'."
+fi
+
+# --- Validation du fichier de sauvegarde ---
+if [ ! -f "$BACKUP_FILE" ]; then
+    error "Le fichier de sauvegarde '$BACKUP_FILE' n'a pas été trouvé."
+fi
+info "Utilisation du fichier de sauvegarde : $BACKUP_FILE"
+
+# --- Arrêt du service Rundeck ---
+info "Arrêt du service Rundeck..."
+if systemctl is-active --quiet rundeckd; then
+    systemctl stop rundeckd || error "Échec de l'arrêt du service Rundeck."
+    success "Service Rundeck arrêté."
+else
+    warn "Le service Rundeck n'était pas en cours d'exécution."
+fi
+
+# --- Création du répertoire d'extraction et extraction ---
+info "Création du répertoire temporaire et extraction de l'archive..."
+mkdir -p "$EXTRACT_DIR"
+tar -xzf "$BACKUP_FILE" -C "$EXTRACT_DIR" || {
+    error "L'extraction de l'archive a échoué."
+    rm -rf "$EXTRACT_DIR"
+    # Redémarrer Rundeck même en cas d'échec
+    info "Tentative de redémarrage du service Rundeck..."
+    systemctl start rundeckd
+    exit 1
+}
+DB_BACKUP_FILE=$(find "$EXTRACT_DIR" -name "*.sql" -type f)
+if [ ! -f "$DB_BACKUP_FILE" ]; then
+    error "Aucun fichier de sauvegarde SQL trouvé dans l'archive."
+    rm -rf "$EXTRACT_DIR"
+    info "Tentative de redémarrage du service Rundeck..."
+    systemctl start rundeckd
+    exit 1
+fi
+success "Archive extraite avec succès dans '$EXTRACT_DIR'."
+
+# --- Restauration de la base de données ---
+info "Restauration de la base de données MySQL '$DB_NAME'..."
+mysql --user="$DB_USER" --password="$DB_PASS" "$DB_NAME" < "$DB_BACKUP_FILE" || {
+    error "La restauration de la base de données a échoué."
+    rm -rf "$EXTRACT_DIR"
+    info "Tentative de redémarrage du service Rundeck..."
+    systemctl start rundeckd
+    exit 1
+}
+success "Base de données restaurée avec succès."
+
+# --- Restauration des fichiers ---
+info "Suppression des anciens répertoires de données Rundeck..."
+rm -rf /var/lib/rundeck/logs /var/lib/rundeck/keystore /var/lib/rundeck/projects /etc/rundeck
+success "Anciens répertoires supprimés."
+
+info "Restauration des nouveaux répertoires..."
+mv "$EXTRACT_DIR/logs" /var/lib/rundeck/
+mv "$EXTRACT_DIR/keystore" /var/lib/rundeck/
+mv "$EXTRACT_DIR/projects" /var/lib/rundeck/
+mv "$EXTRACT_DIR/rundeck" /etc/
+success "Nouveaux répertoires restaurés."
+
+# --- Rétablissement des permissions ---
+info "Rétablissement des permissions pour les fichiers Rundeck..."
+chown -R rundeck:rundeck /var/lib/rundeck /etc/rundeck
+success "Permissions rétablies."
+
+# --- Nettoyage ---
+info "Nettoyage du répertoire d'extraction temporaire..."
+rm -rf "$EXTRACT_DIR"
+success "Répertoire temporaire supprimé."
+
+# --- Redémarrage du service Rundeck ---
+info "Redémarrage du service Rundeck..."
+systemctl start rundeckd || error "Le redémarrage du service Rundeck a échoué."
+success "Service Rundeck redémarré. La première initialisation peut prendre un certain temps."
+
+end_success "Restauration de Rundeck terminée avec succès."

--- a/scripts/restore_rundeck.sh
+++ b/scripts/restore_rundeck.sh
@@ -26,10 +26,14 @@ fi
 BACKUP_FILE="$1"
 
 # --- Variables de Configuration (doivent correspondre à install_mysql.sh) ---
-DB_NAME="rundeck"
-DB_USER="rundeckuser"
-DB_PASS="rundeckpassword"
+DB_NAME="${RUNDECK_DB_NAME}"
+DB_USER="${RUNDECK_DB_USER}"
+DB_PASS="${RUNDECK_DB_PASS}"
 
+# Vérification que les variables d'environnement sont définies
+if [ -z "$DB_NAME" ] || [ -z "$DB_USER" ] || [ -z "$DB_PASS" ]; then
+    error "Les variables d'environnement RUNDECK_DB_NAME, RUNDECK_DB_USER et RUNDECK_DB_PASS doivent être définies."
+fi
 # --- Répertoire Temporaire pour l'Extraction ---
 EXTRACT_DIR="/tmp/rundeck_restore_$$"
 

--- a/scripts/restore_rundeck.sh
+++ b/scripts/restore_rundeck.sh
@@ -89,6 +89,18 @@ mysql --user="$DB_USER" --password="$DB_PASS" "$DB_NAME" < "$DB_BACKUP_FILE" || 
 success "Base de données restaurée avec succès."
 
 # --- Restauration des fichiers ---
+# Vérification de la présence des répertoires requis dans la sauvegarde extraite
+REQUIRED_DIRS=("logs" "keystore" "projects" "rundeck")
+for dir in "${REQUIRED_DIRS[@]}"; do
+    if [ ! -d "$EXTRACT_DIR/$dir" ]; then
+        error "Le répertoire requis '$dir' est manquant dans la sauvegarde extraite."
+        rm -rf "$EXTRACT_DIR"
+        info "Tentative de redémarrage du service Rundeck..."
+        systemctl start rundeckd
+        exit 1
+    fi
+done
+info "Tous les répertoires requis sont présents dans la sauvegarde extraite."
 info "Suppression des anciens répertoires de données Rundeck..."
 rm -rf /var/lib/rundeck/logs /var/lib/rundeck/keystore /var/lib/rundeck/projects /etc/rundeck
 success "Anciens répertoires supprimés."


### PR DESCRIPTION
This change introduces two new scripts, `backup_rundeck.sh` and `restore_rundeck.sh`, to provide backup and restore functionality for the Rundeck installation.

The backup script handles stopping the service, dumping the MySQL database, and archiving key Rundeck directories. The restore script reverses this process, taking a backup file as an argument.

Both scripts are commented in French and follow the existing coding style. The `scripts/README.md` file has been updated to document the usage of these new scripts.

## Summary by Sourcery

Introduce backup and restore scripts for managing Rundeck state and update documentation

New Features:
- Add backup_rundeck.sh to automate stopping Rundeck, dumping the database, archiving key directories, and restarting the service
- Add restore_rundeck.sh to automate restoring Rundeck from a backup including database, files, permissions, and service restart

Documentation:
- Update scripts/README.md to document usage of the new backup and restore scripts