### PR TITLE
feat(nginx): Make server_name configurable

### DIFF
--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -6,3 +6,6 @@ nginx_listen_port: 80
 
 # Port sur lequel Rundeck est exécuté
 rundeck_port: 4440
+
+# Nom du serveur pour Nginx
+nginx_server_name: "{{ ansible_fqdn }}"

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -4,7 +4,7 @@ server {
     listen {{ nginx_listen_port }};
 
     # Nom du serveur (peut être une adresse IP ou un nom de domaine)
-    server_name {{ ansible_fqdn }};
+    server_name {{ nginx_server_name }};
 
     # Emplacement pour la racine du serveur
     location / {


### PR DESCRIPTION
This commit makes the `server_name` directive in the Nginx configuration template configurable.

A new variable, `nginx_server_name`, has been introduced in `defaults/main.yml` with a default value of `{{ ansible_fqdn }}`. The Nginx template (`templates/nginx.conf.j2`) has been updated to use this new variable.

This change increases the reusability of the Nginx Ansible role by allowing users to easily override the server name in their playbook or inventory for different environments.

## Summary by Sourcery

New Features:
- Allow Nginx server_name directive to be configured via the nginx_server_name variable instead of hardcoding ansible_fqdn