### PR TITLE
This commit improves the Ansible Nginx role based on code review feed…

### DIFF
--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -1,8 +1,19 @@
----
-# defaults file for ansible-role-nginx
+# Fichier de variables par défaut pour le rôle Nginx.
 
-# Port d'écoute pour Nginx
+---
+# Port d'écoute pour Nginx.
 nginx_listen_port: 80
 
-# Port sur lequel Rundeck est exécuté
+# Nom du serveur pour Nginx.
+# Par défaut, utilise le nom de domaine complet (FQDN) de la machine.
+# Vous pouvez surcharger cette valeur dans votre inventaire ou playbook.
+nginx_server_name: "{{ ansible_fqdn }}"
+
+# Hôte backend de Rundeck.
+# Par défaut, pointe vers localhost.
+# Modifiez cette valeur si Rundeck tourne sur un autre serveur.
+rundeck_backend_host: "127.0.0.1"
+
+# Port de Rundeck.
+# Assurez-vous que ce port correspond à celui configuré dans le rôle Rundeck.
 rundeck_port: 4440

--- a/ansible/roles/nginx/handlers/main.yml
+++ b/ansible/roles/nginx/handlers/main.yml
@@ -1,7 +1,15 @@
 ---
-# handlers file for ansible-role-nginx
+# Fichier de handlers pour le rôle Nginx.
 
-- name: restart nginx
+- name: "Valider la configuration Nginx"
+  command: "nginx -t"
+  changed_when: false
+  register: nginx_config_test
+  listen: "validate and reload nginx"
+
+- name: "Recharger Nginx"
   service:
     name: nginx
-    state: restarted
+    state: reloaded
+  when: nginx_config_test.rc == 0
+  listen: "validate and reload nginx"

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -19,19 +19,19 @@
   template:
     src: nginx.conf.j2
     dest: /etc/nginx/sites-available/rundeck
-  notify: restart nginx
+  notify: "validate and reload nginx"
 
-# Activation du site Rundeck
+# Activation du site Rundee
 - name: "Activation du site Rundeck"
   file:
     src: /etc/nginx/sites-available/rundeck
     dest: /etc/nginx/sites-enabled/rundeck
     state: link
-  notify: restart nginx
+  notify: "validate and reload nginx"
 
 # Suppression du site par défaut de Nginx
 - name: "Suppression du site par défaut de Nginx"
   file:
     path: /etc/nginx/sites-enabled/default
     state: absent
-  notify: restart nginx
+  notify: "validate and reload nginx"

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -21,7 +21,7 @@
     dest: /etc/nginx/sites-available/rundeck
   notify: "validate and reload nginx"
 
-# Activation du site Rundee
+# Activation du site Rundeck
 - name: "Activation du site Rundeck"
   file:
     src: /etc/nginx/sites-available/rundeck

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -4,12 +4,12 @@ server {
     listen {{ nginx_listen_port }};
 
     # Nom du serveur (peut être une adresse IP ou un nom de domaine)
-    server_name {{ ansible_fqdn }};
+    server_name {{ nginx_server_name }};
 
     # Emplacement pour la racine du serveur
     location / {
         # Adresse du proxy pour Rundeck
-        proxy_pass http://127.0.0.1:{{ rundeck_port }};
+        proxy_pass http://{{ rundeck_backend_host }}:{{ rundeck_port }};
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Server $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
…back.

- The `server_name` is now configurable via the `nginx_server_name` variable, defaulting to `ansible_fqdn`.
- The Rundeck backend host is now configurable via the `rundeck_backend_host` variable, defaulting to `127.0.0.1`.
- The Nginx service handler now validates the configuration with `nginx -t` before reloading the service, preventing downtime from invalid configurations.

## Summary by Sourcery

Introduce variables to configure Nginx server_name and Rundeck backend host, and validate the Nginx configuration before reload

New Features:
- Make Nginx server_name configurable via nginx_server_name
- Make Rundeck backend host configurable via rundeck_backend_host

Enhancements:
- Validate Nginx configuration with nginx -t before reloading the service
- Split the restart handler into separate validation and reload handlers and update task notifications