### PR TITLE
This commit addresses feedback from a code review to improve the robu…

### DIFF
--- a/scripts/backup_rundeck.sh
+++ b/scripts/backup_rundeck.sh
@@ -82,6 +82,18 @@ success "Base de données sauvegardée dans '$DB_BACKUP_FILE'."
 
 # --- Sauvegarde des fichiers ---
 info "Création de l'archive des fichiers de Rundeck..."
+# La commande tar ci-dessous utilise plusieurs options '-C' pour inclure des fichiers et dossiers de différents emplacements.
+# Structure de l'archive résultante :
+# - $(basename "$DB_BACKUP_FILE") (fichier de sauvegarde de la base de données, à la racine de l'archive)
+# - logs/ (dossier de logs Rundeck)
+# - keystore/ (dossier keystore Rundeck)
+# - projects/ (dossier projets Rundeck)
+# - rundeck/ (dossier de configuration /etc/rundeck)
+#
+# La restauration se fait en extrayant l'archive dans un répertoire temporaire,
+# puis en utilisant 'rsync' pour fusionner les répertoires sauvegardés avec
+# les répertoires de destination. Cette méthode préserve les fichiers existants
+# qui ne sont pas dans la sauvegarde.
 tar -czf "$BACKUP_FILE" \
     -C /tmp "$(basename "$DB_BACKUP_FILE")" \
     -C "$(dirname "$RUNDECK_LOGS_DIR")" "$(basename "$RUNDECK_LOGS_DIR")" \

--- a/scripts/restore_rundeck.sh
+++ b/scripts/restore_rundeck.sh
@@ -71,15 +71,29 @@ tar -xzf "$BACKUP_FILE" -C "$EXTRACT_DIR" || {
     systemctl start rundeckd
     exit 1
 }
-DB_BACKUP_FILE=$(find "$EXTRACT_DIR" -name "*.sql" -type f)
-if [ ! -f "$DB_BACKUP_FILE" ]; then
-    error "Aucun fichier de sauvegarde SQL trouvé dans l'archive."
+# --- Vérification du fichier de sauvegarde SQL ---
+info "Vérification du fichier de sauvegarde SQL dans l'archive..."
+SQL_FILES=$(find "$EXTRACT_DIR" -name "*.sql" -type f)
+NUM_SQL_FILES=$(echo "$SQL_FILES" | wc -w)
+
+if [ "$NUM_SQL_FILES" -eq 0 ]; then
+    error "Aucun fichier de sauvegarde SQL (*.sql) n'a été trouvé dans l'archive."
+    rm -rf "$EXTRACT_DIR"
+    info "Tentative de redémarrage du service Rundeck..."
+    systemctl start rundeckd
+    exit 1
+elif [ "$NUM_SQL_FILES" -gt 1 ]; then
+    error "Plusieurs fichiers de sauvegarde SQL ont été trouvés dans l'archive. Restauration annulée."
+    warn "Fichiers trouvés :"
+    echo "$SQL_FILES"
     rm -rf "$EXTRACT_DIR"
     info "Tentative de redémarrage du service Rundeck..."
     systemctl start rundeckd
     exit 1
 fi
-success "Archive extraite avec succès dans '$EXTRACT_DIR'."
+
+DB_BACKUP_FILE="$SQL_FILES"
+success "Fichier de sauvegarde SQL unique trouvé : $DB_BACKUP_FILE"
 
 # --- Restauration de la base de données ---
 info "Restauration de la base de données MySQL '$DB_NAME'..."
@@ -117,17 +131,19 @@ for dir in "${REQUIRED_DIRS[@]}"; do
     fi
 done
 info "Tous les répertoires requis sont présents dans la sauvegarde extraite."
-info "Suppression des anciens répertoires de données Rundeck..."
-rm -rf /var/lib/rundeck/logs /var/lib/rundeck/keystore /var/lib/rundeck/projects /etc/rundeck
-success "Anciens répertoires supprimés."
+info "Restauration des fichiers de Rundeck..."
+warn "Cette opération fusionne les fichiers de la sauvegarde avec les fichiers existants."
+warn "Les fichiers de la sauvegarde écraseront les fichiers existants en cas de conflit."
+warn "Aucun fichier existant non présent dans la sauvegarde ne sera supprimé."
 
-info "Restauration des nouveaux répertoires..."
-mv "$EXTRACT_DIR/logs" /var/lib/rundeck/
-mv "$EXTRACT_DIR/keystore" /var/lib/rundeck/
-mv "$EXTRACT_DIR/projects" /var/lib/rundeck/
-info "Fusion des fichiers restaurés dans /etc/rundeck (les fichiers existants seront écrasés si présents)..."
+# Utilisation de rsync pour une restauration plus sûre qui ne supprime pas de fichiers inattendus.
+info "Restauration des répertoires de données..."
+rsync -a "$EXTRACT_DIR/logs/" /var/lib/rundeck/logs/
+rsync -a "$EXTRACT_DIR/keystore/" /var/lib/rundeck/keystore/
+rsync -a "$EXTRACT_DIR/projects/" /var/lib/rundeck/projects/
+info "Restauration et fusion du répertoire de configuration..."
 rsync -a "$EXTRACT_DIR/rundeck/" /etc/rundeck/
-success "Nouveaux répertoires restaurés et fusionnés dans /etc/rundeck."
+success "Restauration des fichiers terminée."
 
 # --- Rétablissement des permissions ---
 info "Rétablissement des permissions pour les fichiers Rundeck..."


### PR DESCRIPTION
…stness and safety of the Rundeck backup and restore scripts.

Key changes:

- `scripts/restore_rundeck.sh`:
  - Added a check to ensure only one `.sql` backup file exists in the archive to prevent ambiguity during restoration.
  - Replaced destructive `rm -rf` and `mv` commands with `rsync` to merge backed-up directories. This prevents accidental deletion of untracked configuration files, making the restore process safer.

- `scripts/backup_rundeck.sh`:
  - Updated comments to accurately document the archive structure and the new `rsync`-based restoration process.
  - Verified that the script already contains a check for backup archive integrity before deleting the temporary SQL dump file.